### PR TITLE
 Do not highlight used aliases

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -55,6 +55,11 @@ export function activate(context: vscode.ExtensionContext) {
                 let splitNameSpace = match[1].split('\\');
                 let className = splitNameSpace[splitNameSpace.length - 1];
                 
+                if (className.search(/ as /) > -1 ) {
+                    let splitAlias = className.split(' as ');
+                    className = splitAlias[splitAlias.length - 1].trim();
+                }
+                
                 let found = (text.match(new RegExp(className, 'g')) || []).length;
 
                 const startPos = editor.document.positionAt(match.index);


### PR DESCRIPTION
I modified the code to be compatible with aliases.
If an alias is defined, check if it is used instead of checking with the original class name.